### PR TITLE
chore: Retiring non-AVM modules

### DIFF
--- a/modules/ai/bing-resource/ARCHIVED.md
+++ b/modules/ai/bing-resource/ARCHIVED.md
@@ -2,5 +2,5 @@
 
 Past releases of this module are archived here:
 
-- [ai/bing-resource/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/bing-resource/1.0.1)
-- [ai/bing-resource/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/bing-resource/1.0.2)
+- [ai/bing-resource/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/bing-resource/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/ai/bing-resource/1.0.1/modules/ai/bing-resource))
+- [ai/bing-resource/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/bing-resource/1.0.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/ai/bing-resource/1.0.2/modules/ai/bing-resource))

--- a/modules/ai/cognitiveservices/ARCHIVED.md
+++ b/modules/ai/cognitiveservices/ARCHIVED.md
@@ -2,9 +2,9 @@
 
 Past releases of this module are archived here:
 
-- [ai/cognitiveservices/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/cognitiveservices/1.0.1)
-- [ai/cognitiveservices/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/cognitiveservices/1.0.2)
-- [ai/cognitiveservices/1.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/cognitiveservices/1.0.3)
-- [ai/cognitiveservices/1.0.4](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/cognitiveservices/1.0.4)
-- [ai/cognitiveservices/1.0.5](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/cognitiveservices/1.0.5)
-- [ai/cognitiveservices/1.1.1](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/cognitiveservices/1.1.1)
+- [ai/cognitiveservices/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/cognitiveservices/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/ai/cognitiveservices/1.0.1/modules/ai/cognitiveservices))
+- [ai/cognitiveservices/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/cognitiveservices/1.0.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/ai/cognitiveservices/1.0.2/modules/ai/cognitiveservices))
+- [ai/cognitiveservices/1.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/cognitiveservices/1.0.3) - ([source](https://github.com/Azure/bicep-registry-modules/tree/ai/cognitiveservices/1.0.3/modules/ai/cognitiveservices))
+- [ai/cognitiveservices/1.0.4](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/cognitiveservices/1.0.4) - ([source](https://github.com/Azure/bicep-registry-modules/tree/ai/cognitiveservices/1.0.4/modules/ai/cognitiveservices))
+- [ai/cognitiveservices/1.0.5](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/cognitiveservices/1.0.5) - ([source](https://github.com/Azure/bicep-registry-modules/tree/ai/cognitiveservices/1.0.5/modules/ai/cognitiveservices))
+- [ai/cognitiveservices/1.1.1](https://github.com/Azure/bicep-registry-modules/releases/tag/ai/cognitiveservices/1.1.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/ai/cognitiveservices/1.1.1/modules/ai/cognitiveservices))

--- a/modules/app/app-configuration/ARCHIVED.md
+++ b/modules/app/app-configuration/ARCHIVED.md
@@ -2,6 +2,6 @@
 
 Past releases of this module are archived here:
 
-- [app/app-configuration/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/app/app-configuration/1.0.1)
-- [app/app-configuration/1.1.1](https://github.com/Azure/bicep-registry-modules/releases/tag/app/app-configuration/1.1.1)
-- [app/app-configuration/1.1.2](https://github.com/Azure/bicep-registry-modules/releases/tag/app/app-configuration/1.1.2)
+- [app/app-configuration/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/app/app-configuration/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/app/app-configuration/1.0.1/modules/app/app-configuration))
+- [app/app-configuration/1.1.1](https://github.com/Azure/bicep-registry-modules/releases/tag/app/app-configuration/1.1.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/app/app-configuration/1.1.1/modules/app/app-configuration))
+- [app/app-configuration/1.1.2](https://github.com/Azure/bicep-registry-modules/releases/tag/app/app-configuration/1.1.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/app/app-configuration/1.1.2/modules/app/app-configuration))

--- a/modules/authorization/resource-scope-role-assignment/ARCHIVED.md
+++ b/modules/authorization/resource-scope-role-assignment/ARCHIVED.md
@@ -2,5 +2,5 @@
 
 Past releases of this module are archived here:
 
-- [authorization/resource-scope-role-assignment/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/authorization/resource-scope-role-assignment/1.0.1)
-- [authorization/resource-scope-role-assignment/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/authorization/resource-scope-role-assignment/1.0.2)
+- [authorization/resource-scope-role-assignment/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/authorization/resource-scope-role-assignment/1.0.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/authorization/resource-scope-role-assignment/1.0.1/modules/authorization/resource-scope-role-assignment))
+- [authorization/resource-scope-role-assignment/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/authorization/resource-scope-role-assignment/1.0.2)- ([source](https://github.com/Azure/bicep-registry-modules/tree/authorization/resource-scope-role-assignment/1.0.2/modules/authorization/resource-scope-role-assignment))

--- a/modules/compute/availability-set/ARCHIVED.md
+++ b/modules/compute/availability-set/ARCHIVED.md
@@ -2,5 +2,5 @@
 
 Past releases of this module are archived here:
 
-- [compute/availability-set/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/availability-set/1.0.1)
-- [compute/availability-set/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/availability-set/1.0.2)
+- [compute/availability-set/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/availability-set/1.0.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/compute/availability-set/1.0.1/modules/compute/availability-set))
+- [compute/availability-set/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/availability-set/1.0.2)- ([source](https://github.com/Azure/bicep-registry-modules/tree/compute/availability-set/1.0.2/modules/compute/availability-set))

--- a/modules/compute/container-registry/ARCHIVED.md
+++ b/modules/compute/container-registry/ARCHIVED.md
@@ -2,7 +2,7 @@
 
 Past releases of this module are archived here:
 
-- [compute/container-registry/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/container-registry/1.0.1)
-- [compute/container-registry/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/container-registry/1.0.2)
-- [compute/container-registry/1.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/container-registry/1.0.3)
-- [compute/container-registry/1.1.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/container-registry/1.1.1)
+- [compute/container-registry/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/container-registry/1.0.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/compute/container-registry/1.0.1/modules/compute/container-registry))
+- [compute/container-registry/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/container-registry/1.0.2)- ([source](https://github.com/Azure/bicep-registry-modules/tree/compute/container-registry/1.0.2/modules/compute/container-registry))
+- [compute/container-registry/1.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/container-registry/1.0.3)- ([source](https://github.com/Azure/bicep-registry-modules/tree/compute/container-registry/1.0.3/modules/compute/container-registry))
+- [compute/container-registry/1.1.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/container-registry/1.1.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/compute/container-registry/1.1.1/modules/compute/container-registry))

--- a/modules/compute/event-hub/ARCHIVED.md
+++ b/modules/compute/event-hub/ARCHIVED.md
@@ -2,7 +2,7 @@
 
 Past releases of this module are archived here:
 
-- [compute/event-hub/0.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/event-hub/0.0.1)
-- [compute/event-hub/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/event-hub/1.0.1)
-- [compute/event-hub/2.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/event-hub/2.0.1)
-- [compute/event-hub/2.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/event-hub/2.0.2)
+- [compute/event-hub/0.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/event-hub/0.0.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/compute/event-hub/0.0.1/modules/compute/event-hub))
+- [compute/event-hub/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/event-hub/1.0.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/compute/event-hub/1.0.1/modules/compute/event-hub))
+- [compute/event-hub/2.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/event-hub/2.0.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/compute/event-hub/2.0.1/modules/compute/event-hub))
+- [compute/event-hub/2.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/event-hub/2.0.2)- ([source](https://github.com/Azure/bicep-registry-modules/tree/compute/event-hub/2.0.2/modules/compute/event-hub))

--- a/modules/compute/function-app/ARCHIVED.md
+++ b/modules/compute/function-app/ARCHIVED.md
@@ -2,7 +2,7 @@
 
 Past releases of this module are archived here:
 
-- [compute/function-app/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/function-app/1.0.1)
-- [compute/function-app/1.1.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/function-app/1.1.1)
-- [compute/function-app/1.1.2](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/function-app/1.1.2)
-- [compute/function-app/2.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/function-app/2.0.1)
+- [compute/function-app/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/function-app/1.0.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/compute/function-app/1.0.1/modules/compute/function-app))
+- [compute/function-app/1.1.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/function-app/1.1.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/compute/function-app/1.1.1/modules/compute/function-app))
+- [compute/function-app/1.1.2](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/function-app/1.1.2)- ([source](https://github.com/Azure/bicep-registry-modules/tree/compute/function-app/1.1.2/modules/compute/function-app))
+- [compute/function-app/2.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/compute/function-app/2.0.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/compute/function-app/2.0.1/modules/compute/function-app))

--- a/modules/identity/user-assigned-identity/ARCHIVED.md
+++ b/modules/identity/user-assigned-identity/ARCHIVED.md
@@ -2,5 +2,5 @@
 
 Past releases of this module are archived here:
 
-- [identity/user-assigned-identity/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/identity/user-assigned-identity/1.0.1)
-- [identity/user-assigned-identity/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/identity/user-assigned-identity/1.0.2)
+- [identity/user-assigned-identity/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/identity/user-assigned-identity/1.0.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/identity/user-assigned-identity/1.0.1/1.0.1/modules/identity/user-assigned-identity))
+- [identity/user-assigned-identity/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/identity/user-assigned-identity/1.0.2)- ([source](https://github.com/Azure/bicep-registry-modules/tree/identity/user-assigned-identity/1.0.2/1.0.1/modules/identity/user-assigned-identity))

--- a/modules/network/dns-zone/ARCHIVED.md
+++ b/modules/network/dns-zone/ARCHIVED.md
@@ -2,5 +2,5 @@
 
 Past releases of this module are archived here:
 
-- [network/dns-zone/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/dns-zone/1.0.1)
-- [network/dns-zone/1.0.4](https://github.com/Azure/bicep-registry-modules/releases/tag/network/dns-zone/1.0.4)
+- [network/dns-zone/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/dns-zone/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/network/dns-zone/1.0.1/modules/network/dns-zone))
+- [network/dns-zone/1.0.4](https://github.com/Azure/bicep-registry-modules/releases/tag/network/dns-zone/1.0.4) - ([source](https://github.com/Azure/bicep-registry-modules/tree/network/dns-zone/1.0.4/modules/network/dns-zone))

--- a/modules/network/nat-gateway/ARCHIVED.md
+++ b/modules/network/nat-gateway/ARCHIVED.md
@@ -2,5 +2,5 @@
 
 Past releases of this module are archived here:
 
-- [network/nat-gateway/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/nat-gateway/1.0.1)
-- [network/nat-gateway/1.0.4](https://github.com/Azure/bicep-registry-modules/releases/tag/network/nat-gateway/1.0.4)
+- [network/nat-gateway/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/nat-gateway/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/network/nat-gateway/1.0.1/modules/network/nat-gateway))
+- [network/nat-gateway/1.0.4](https://github.com/Azure/bicep-registry-modules/releases/tag/network/nat-gateway/1.0.4) - ([source](https://github.com/Azure/bicep-registry-modules/tree/network/nat-gateway/1.0.4/modules/network/nat-gateway))

--- a/modules/network/private-dns-zone/ARCHIVED.md
+++ b/modules/network/private-dns-zone/ARCHIVED.md
@@ -2,4 +2,4 @@
 
 Past releases of this module are archived here:
 
-- [network/private-dns-zone/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/private-dns-zone/1.0.1)
+- [network/private-dns-zone/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/private-dns-zone/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/network/private-dns-zone/1.0.1/modules/network/private-dns-zone))

--- a/modules/network/public-ip-address/ARCHIVED.md
+++ b/modules/network/public-ip-address/ARCHIVED.md
@@ -2,5 +2,5 @@
 
 Past releases of this module are archived here:
 
-- [network/public-ip-address/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/public-ip-address/1.0.1)
-- [network/public-ip-address/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/network/public-ip-address/1.0.2)
+- [network/public-ip-address/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/public-ip-address/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/network/public-ip-address/1.0.1/modules/network/public-ip-address))
+- [network/public-ip-address/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/network/public-ip-address/1.0.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/network/public-ip-address/1.0.2/modules/network/public-ip-address))

--- a/modules/network/public-ip-prefix/ARCHIVED.md
+++ b/modules/network/public-ip-prefix/ARCHIVED.md
@@ -2,5 +2,5 @@
 
 Past releases of this module are archived here:
 
-- [network/public-ip-prefix/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/public-ip-prefix/1.0.1)
-- [network/public-ip-prefix/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/network/public-ip-prefix/1.0.2)
+- [network/public-ip-prefix/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/public-ip-prefix/1.0.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/network/public-ip-prefix/1.0.1/modules/network/public-ip-prefix))
+- [network/public-ip-prefix/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/network/public-ip-prefix/1.0.2)- ([source](https://github.com/Azure/bicep-registry-modules/tree/network/public-ip-prefix/1.0.2/modules/network/public-ip-prefix))

--- a/modules/network/traffic-manager/ARCHIVED.md
+++ b/modules/network/traffic-manager/ARCHIVED.md
@@ -2,10 +2,10 @@
 
 Past releases of this module are archived here:
 
-- [network/traffic-manager/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/traffic-manager/1.0.1)
-- [network/traffic-manager/2.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/traffic-manager/2.0.1)
-- [network/traffic-manager/2.1.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/traffic-manager/2.1.1)
-- [network/traffic-manager/2.2.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/traffic-manager/2.2.1)
-- [network/traffic-manager/2.3.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/traffic-manager/2.3.1)
-- [network/traffic-manager/2.3.2](https://github.com/Azure/bicep-registry-modules/releases/tag/network/traffic-manager/2.3.2)
-- [network/traffic-manager/2.3.3](https://github.com/Azure/bicep-registry-modules/releases/tag/network/traffic-manager/2.3.3)
+- [network/traffic-manager/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/traffic-manager/1.0.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/network/traffic-manager/1.0.1/modules/network/traffic-manager))
+- [network/traffic-manager/2.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/traffic-manager/2.0.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/network/traffic-manager/2.0.1/modules/network/traffic-manager))
+- [network/traffic-manager/2.1.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/traffic-manager/2.1.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/network/traffic-manager/2.1.1/modules/network/traffic-manager))
+- [network/traffic-manager/2.2.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/traffic-manager/2.2.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/network/traffic-manager/2.2.1/modules/network/traffic-manager))
+- [network/traffic-manager/2.3.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/traffic-manager/2.3.1)- ([source](https://github.com/Azure/bicep-registry-modules/tree/network/traffic-manager/2.3.1/modules/network/traffic-manager))
+- [network/traffic-manager/2.3.2](https://github.com/Azure/bicep-registry-modules/releases/tag/network/traffic-manager/2.3.2)- ([source](https://github.com/Azure/bicep-registry-modules/tree/network/traffic-manager/2.3.2/modules/network/traffic-manager))
+- [network/traffic-manager/2.3.3](https://github.com/Azure/bicep-registry-modules/releases/tag/network/traffic-manager/2.3.3)- ([source](https://github.com/Azure/bicep-registry-modules/tree/network/traffic-manager/2.3.3/modules/network/traffic-manager))

--- a/modules/network/virtual-network/ARCHIVED.md
+++ b/modules/network/virtual-network/ARCHIVED.md
@@ -2,9 +2,9 @@
 
 Past releases of this module are archived here:
 
-- [network/virtual-network/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/virtual-network/1.0.1)
-- [network/virtual-network/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/network/virtual-network/1.0.2)
-- [network/virtual-network/1.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/network/virtual-network/1.0.3)
-- [network/virtual-network/1.1.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/virtual-network/1.1.1)
-- [network/virtual-network/1.1.2](https://github.com/Azure/bicep-registry-modules/releases/tag/network/virtual-network/1.1.2)
-- [network/virtual-network/1.1.3](https://github.com/Azure/bicep-registry-modules/releases/tag/network/virtual-network/1.1.3)
+- [network/virtual-network/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/virtual-network/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/network/virtual-network/1.0.1/modules/network/virtual-network))
+- [network/virtual-network/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/network/virtual-network/1.0.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/network/virtual-network/1.0.2/modules/network/virtual-network))
+- [network/virtual-network/1.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/network/virtual-network/1.0.3) - ([source](https://github.com/Azure/bicep-registry-modules/tree/network/virtual-network/1.0.3/modules/network/virtual-network))
+- [network/virtual-network/1.1.1](https://github.com/Azure/bicep-registry-modules/releases/tag/network/virtual-network/1.1.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/network/virtual-network/1.1.1/modules/network/virtual-network))
+- [network/virtual-network/1.1.2](https://github.com/Azure/bicep-registry-modules/releases/tag/network/virtual-network/1.1.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/network/virtual-network/1.1.2/modules/network/virtual-network))
+- [network/virtual-network/1.1.3](https://github.com/Azure/bicep-registry-modules/releases/tag/network/virtual-network/1.1.3) - ([source](https://github.com/Azure/bicep-registry-modules/tree/network/virtual-network/1.1.3/modules/network/virtual-network))

--- a/modules/samples/array-loop/ARCHIVED.md
+++ b/modules/samples/array-loop/ARCHIVED.md
@@ -2,6 +2,6 @@
 
 Past releases of this module are archived here:
 
-- [samples/array-loop/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/samples/array-loop/1.0.1)
-- [samples/array-loop/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/samples/array-loop/1.0.2)
-- [samples/array-loop/1.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/samples/array-loop/1.0.3)
+- [samples/array-loop/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/samples/array-loop/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/samples/array-loop/1.0.1/modules/samples/array-loop))
+- [samples/array-loop/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/samples/array-loop/1.0.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/samples/array-loop/1.0.2/modules/samples/array-loop))
+- [samples/array-loop/1.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/samples/array-loop/1.0.3) - ([source](https://github.com/Azure/bicep-registry-modules/tree/samples/array-loop/1.0.3/modules/samples/array-loop))

--- a/modules/samples/hello-world/ARCHIVED.md
+++ b/modules/samples/hello-world/ARCHIVED.md
@@ -2,7 +2,7 @@
 
 Past releases of this module are archived here:
 
-- [samples/hello-world/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/samples/hello-world/1.0.1)
-- [samples/hello-world/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/samples/hello-world/1.0.2)
-- [samples/hello-world/1.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/samples/hello-world/1.0.3)
-- [samples/hello-world/1.0.4](https://github.com/Azure/bicep-registry-modules/releases/tag/samples/hello-world/1.0.4)
+- [samples/hello-world/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/samples/hello-world/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/samples/hello-world/1.0.1/modules/samples/hello-world))
+- [samples/hello-world/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/samples/hello-world/1.0.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/samples/hello-world/1.0.2/modules/samples/hello-world))
+- [samples/hello-world/1.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/samples/hello-world/1.0.3) - ([source](https://github.com/Azure/bicep-registry-modules/tree/samples/hello-world/1.0.3/modules/samples/hello-world))
+- [samples/hello-world/1.0.4](https://github.com/Azure/bicep-registry-modules/releases/tag/samples/hello-world/1.0.4) - ([source](https://github.com/Azure/bicep-registry-modules/tree/samples/hello-world/1.0.4/modules/samples/hello-world))

--- a/modules/search/search-service/ARCHIVED.md
+++ b/modules/search/search-service/ARCHIVED.md
@@ -2,5 +2,5 @@
 
 Past releases of this module are archived here:
 
-- [search/search-service/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/search/search-service/1.0.1)
-- [search/search-service/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/search/search-service/1.0.2)
+- [search/search-service/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/search/search-service/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/search/search-service/1.0.1/modules/search/search-service))
+- [search/search-service/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/search/search-service/1.0.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/search/search-service/1.0.2/modules/search/search-service))

--- a/modules/security/keyvault/ARCHIVED.md
+++ b/modules/security/keyvault/ARCHIVED.md
@@ -2,5 +2,5 @@
 
 Past releases of this module are archived here:
 
-- [security/keyvault/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/security/keyvault/1.0.1)
-- [security/keyvault/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/security/keyvault/1.0.2)
+- [security/keyvault/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/security/keyvault/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/security/keyvault/1.0.1/modules/security/keyvault))
+- [security/keyvault/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/security/keyvault/1.0.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/security/keyvault/1.0.2/modules/security/keyvault))

--- a/modules/storage/cosmos-db/ARCHIVED.md
+++ b/modules/storage/cosmos-db/ARCHIVED.md
@@ -2,7 +2,7 @@
 
 Past releases of this module are archived here:
 
-- [storage/cosmos-db/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/cosmos-db/1.0.1)
-- [storage/cosmos-db/2.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/cosmos-db/2.0.1)
-- [storage/cosmos-db/3.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/cosmos-db/3.0.1)
-- [storage/cosmos-db/3.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/cosmos-db/3.0.2)
+- [storage/cosmos-db/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/cosmos-db/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/cosmos-db/1.0.1/modules/storage/cosmos-db))
+- [storage/cosmos-db/2.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/cosmos-db/2.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/cosmos-db/2.0.1/modules/storage/cosmos-db))
+- [storage/cosmos-db/3.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/cosmos-db/3.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/cosmos-db/3.0.1/modules/storage/cosmos-db))
+- [storage/cosmos-db/3.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/cosmos-db/3.0.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/cosmos-db/3.0.2/modules/storage/cosmos-db))

--- a/modules/storage/log-analytics-workspace/ARCHIVED.md
+++ b/modules/storage/log-analytics-workspace/ARCHIVED.md
@@ -2,6 +2,6 @@
 
 Past releases of this module are archived here:
 
-- [storage/log-analytics-workspace/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/log-analytics-workspace/1.0.1)
-- [storage/log-analytics-workspace/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/log-analytics-workspace/1.0.2)
-- [storage/log-analytics-workspace/1.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/log-analytics-workspace/1.0.3)
+- [storage/log-analytics-workspace/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/log-analytics-workspace/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/log-analytics-workspace/1.0.1/modules/storage/log-analytics-workspace))
+- [storage/log-analytics-workspace/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/log-analytics-workspace/1.0.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/log-analytics-workspace/1.0.2/modules/storage/log-analytics-workspace))
+- [storage/log-analytics-workspace/1.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/log-analytics-workspace/1.0.3) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/log-analytics-workspace/1.0.3/modules/storage/log-analytics-workspace))

--- a/modules/storage/mysql-single-server/ARCHIVED.md
+++ b/modules/storage/mysql-single-server/ARCHIVED.md
@@ -2,6 +2,6 @@
 
 Past releases of this module are archived here:
 
-- [storage/mysql-single-server/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/mysql-single-server/1.0.1)
-- [storage/mysql-single-server/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/mysql-single-server/1.0.2)
-- [storage/mysql-single-server/1.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/mysql-single-server/1.0.3)
+- [storage/mysql-single-server/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/mysql-single-server/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/mysql-single-server/1.0.1/modules/storage/mysql-single-server))
+- [storage/mysql-single-server/1.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/mysql-single-server/1.0.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/mysql-single-server/1.0.2/modules/storage/mysql-single-server))
+- [storage/mysql-single-server/1.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/mysql-single-server/1.0.3) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/mysql-single-server/1.0.3/modules/storage/mysql-single-server))

--- a/modules/storage/postgresql-single-server/ARCHIVED.md
+++ b/modules/storage/postgresql-single-server/ARCHIVED.md
@@ -2,6 +2,6 @@
 
 Past releases of this module are archived here:
 
-- [storage/postgresql-single-server/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/postgresql-single-server/1.0.1)
-- [storage/postgresql-single-server/1.1.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/postgresql-single-server/1.1.1)
-- [storage/postgresql-single-server/1.1.2](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/postgresql-single-server/1.1.2)
+- [storage/postgresql-single-server/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/postgresql-single-server/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/postgresql-single-server/1.0.1/modules/storage/postgresql-single-server))
+- [storage/postgresql-single-server/1.1.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/postgresql-single-server/1.1.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/postgresql-single-server/1.1.1/modules/storage/postgresql-single-server))
+- [storage/postgresql-single-server/1.1.2](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/postgresql-single-server/1.1.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/postgresql-single-server/1.1.2/modules/storage/postgresql-single-server))

--- a/modules/storage/redis-cache/ARCHIVED.md
+++ b/modules/storage/redis-cache/ARCHIVED.md
@@ -2,6 +2,6 @@
 
 Past releases of this module are archived here:
 
-- [storage/redis-cache/0.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/redis-cache/0.0.1)
-- [storage/redis-cache/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/redis-cache/1.0.1)
-- [storage/redis-cache/2.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/redis-cache/2.0.1)
+- [storage/redis-cache/0.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/redis-cache/0.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/redis-cache/0.0.1/modules/storage/redis-cache))
+- [storage/redis-cache/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/redis-cache/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/redis-cache/1.0.1/modules/storage/redis-cache))
+- [storage/redis-cache/2.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/redis-cache/2.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/redis-cache/2.0.1/modules/storage/redis-cache))

--- a/modules/storage/storage-account/ARCHIVED.md
+++ b/modules/storage/storage-account/ARCHIVED.md
@@ -2,9 +2,9 @@
 
 Past releases of this module are archived here:
 
-- [storage/storage-account/0.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/storage-account/0.0.1)
-- [storage/storage-account/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/storage-account/1.0.1)
-- [storage/storage-account/2.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/storage-account/2.0.1)
-- [storage/storage-account/2.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/storage-account/2.0.2)
-- [storage/storage-account/2.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/storage-account/2.0.3)
-- [storage/storage-account/3.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/storage-account/3.0.1)
+- [storage/storage-account/0.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/storage-account/0.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/storage-account/0.0.1/modules/storage/storage-account))
+- [storage/storage-account/1.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/storage-account/1.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/storage-account/1.0.1/modules/storage/storage-account))
+- [storage/storage-account/2.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/storage-account/2.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/storage-account/2.0.1/modules/storage/storage-account))
+- [storage/storage-account/2.0.2](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/storage-account/2.0.2) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/storage-account/2.0.2/modules/storage/storage-account))
+- [storage/storage-account/2.0.3](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/storage-account/2.0.3) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/storage-account/2.0.3/modules/storage/storage-account))
+- [storage/storage-account/3.0.1](https://github.com/Azure/bicep-registry-modules/releases/tag/storage/storage-account/3.0.1) - ([source](https://github.com/Azure/bicep-registry-modules/tree/storage/storage-account/3.0.1/modules/storage/storage-account))


### PR DESCRIPTION
## Description

This PR retires the remaining 17 non-AVM modules. It also includes updates the `ARCHIVED.md` file of the already retired modules with direct links to their source code.